### PR TITLE
Fix handling of I2C Errata E302

### DIFF
--- a/platform/emlib/src/em_i2c.c
+++ b/platform/emlib/src/em_i2c.c
@@ -749,7 +749,7 @@ I2C_TransferReturn_TypeDef I2C_Transfer(I2C_TypeDef *i2c)
           // Errata I2C_E303. I2C Fails to Indicate New Incoming Data.
           uint32_t status = i2c->STATUS;
           // look for invalid RXDATAV = 0 and RXFULL = 1 condition
-          if (((status & I2C_IF_RXDATAV) == 0) & ((status & I2C_IF_RXFULL) != 0)) {
+          if (((status & I2C_STATUS_RXDATAV) == 0) & ((status & I2C_STATUS_RXFULL) != 0)) {
             // Performing a dummy read of the RXFIFO (I2C_RXDATA).
             // This restores the expected RXDATAV = 1 and RXFULL = 0 condition.
             (void)i2c->RXDATA;


### PR DESCRIPTION
In the original E303 workaround, the application reads `i2c->status`, but compares the result to the interrupt flags.
Instead, the bits must be compares against `I2C_STATUS_RXDATAV` and `I2C_STATUS_RXFULL`, respectively