### PR TITLE
Refactoring the platform init functions

### DIFF
--- a/platform/radio/wifi/wfx_fmac_driver/bus/sl_wfx_bus_spi.c
+++ b/platform/radio/wifi/wfx_fmac_driver/bus/sl_wfx_bus_spi.c
@@ -85,11 +85,6 @@ sl_status_t sl_wfx_init_bus(void)
   sl_status_t status;
   uint32_t value32;
 
-  status = sl_wfx_host_init_bus();
-  SL_WFX_ERROR_CHECK(status);
-
-  sl_wfx_host_reset_chip();
-
   status = sl_wfx_reg_read_32(SL_WFX_CONFIG_REG_ID, &value32);
   SL_WFX_ERROR_CHECK(status);
 

--- a/platform/radio/wifi/wfx_fmac_driver/sl_wfx_host_api.h
+++ b/platform/radio/wifi/wfx_fmac_driver/sl_wfx_host_api.h
@@ -101,15 +101,6 @@ sl_status_t sl_wfx_host_deinit(void);
 
 /* GPIO interface */
 /**************************************************************************//**
- * @brief Implement the reset of the WFx chip
- * @returns Returns SL_STATUS_OK if successful, SL_STATUS_FAIL otherwise
- *
- * @note This function asserts the reset pin of the WFx chip for a while before
- * returning
- *****************************************************************************/
-sl_status_t sl_wfx_host_reset_chip(void);
-
-/**************************************************************************//**
  * @brief Drive the wake up pin in the requested state
  *
  * @param state to be applied to the wake up pin
@@ -248,14 +239,6 @@ sl_status_t sl_wfx_host_lock(void);
 sl_status_t sl_wfx_host_unlock(void);
 
 /* WF200 host bus API */
-/**************************************************************************//**
- * @brief Initialize the host bus
- * @returns Returns SL_STATUS_OK if successful, SL_STATUS_FAIL otherwise
- *
- * @note Called once during the driver initialization phase
- *****************************************************************************/
-sl_status_t sl_wfx_host_init_bus(void);
-
 /**************************************************************************//**
  * @brief Deinitialize the host bus
  * @returns Returns SL_STATUS_OK if successful, SL_STATUS_FAIL otherwise


### PR DESCRIPTION
What is being fixed? Examples:
Platform init functions refactoring

What's in this PR
platform init related function are moved to EFR platform init file

Testing
How was this tested? (at least one bullet point required)
basic test cases run manually on mg12+rs9116 and wf200 also