### PR TITLE
Fix valid input value limits for SERIAL_API_SETUP_CMD_TX_POWERLEVEL_SET_16_BIT

### DIFF
--- a/protocol/z-wave/Apps/SerialAPI/cmds_management.c
+++ b/protocol/z-wave/Apps/SerialAPI/cmds_management.c
@@ -305,9 +305,9 @@ void func_id_serial_api_setup(uint8_t inputLength,
       iTxPower = (zpal_tx_power_t)GET_16BIT_VALUE(&pInputBuffer[1]);
       iAdjust  = (zpal_tx_power_t)GET_16BIT_VALUE(&pInputBuffer[3]);
 
-      /* Only allow power level between -10dBm and 10dBm (API is in deci dBm) */
+      /* Only allow power level between -6dBm and 14dBm (API is in deci dBm) */
       if ((   iTxPower >= (zpal_radio_get_minimum_lr_tx_power() * 10) )
-          && (iTxPower <=  MAX(APP_MAX_TX_POWER, zpal_radio_get_maximum_lr_tx_power()) )
+          && (iTxPower <=  MAX(APP_MAX_TX_POWER_LR, zpal_radio_get_maximum_lr_tx_power() * 10) )
           && (iAdjust  >=  -ZW_TX_POWER_20DBM)
           && (iAdjust  <=  ZW_TX_POWER_20DBM )  /* We might not need these checks as these are made for calibration and
                                                  * we can't tell in advance how large or small the value needs to be. */


### PR DESCRIPTION
Max value for iTxPower should be 140 deci dBm or 14.0 dBm  and not 1.4 dBm.

Debug log from customized ZPC from UnifySDK 1.2.0,
shows that attempt to set value normal_tx_power_dbm: 130 (13 dBm) will fail:

```
INFO: [zwave_rx] Z-Wave API module RF region 0

DEBUG: [zwapi_connection] Outgoing Z-Wave API frame (hex): Length=08 Type=00 Cmd=0B 12 00 82 00 00 6C 
DEBUG: [zwapi_session] Got Z-Wave API response frame (hex): Length=05 Type=01 Cmd=0B 12 00 
WARNING: [zwave_rx] Z-Wave module power setting could not be applied. Command status: 1.
WARNING: [zwave_rx] Running with default power
```


Attempt to set value normal_tx_power_dbm: 14 (1.4dBm) will succeed 

```
DEBUG: [zwapi_connection] Outgoing Z-Wave API frame (hex): Length=08 Type=00 Cmd=0B 12 00 0E 00 00 E0 
DEBUG: [zwapi_session] Got Z-Wave API response frame (hex): Length=05 Type=01 Cmd=0B 12 01 
```
