### PR TITLE
fix: Add `extern "C"` to `em_eusart.h`

### DIFF
--- a/platform/emlib/inc/em_eusart.h
+++ b/platform/emlib/inc/em_eusart.h
@@ -35,6 +35,10 @@
 #include "em_eusart_compat.h"
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* *INDENT-OFF* */
 // *****************************************************************************
 /// @addtogroup eusart EUSART - Extended USART
@@ -1154,6 +1158,10 @@ __STATIC_INLINE void EUSART_IntSet(EUSART_TypeDef *eusart, uint32_t flags)
 {
   eusart->IF_SET = flags;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} (end addtogroup eusart) */
 #endif /* defined(EUART_PRESENT) || defined(EUSART_PRESENT) */


### PR DESCRIPTION
Put most of the contents of `platform/emlib/inc/em_eusart.h` into a `extern "C"` block.

It looks like this is how it has been done for most other header files.