### PR TITLE
Fix memory corruption in sl_cli_input.c

### DIFF
--- a/platform/service/cli/src/sl_cli_input.c
+++ b/platform/service/cli/src/sl_cli_input.c
@@ -34,6 +34,7 @@
 #include "sli_cli_input.h"
 #include "sl_cli_command.h"
 #include "sli_cli_io.h"
+#include "sl_string.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -314,7 +315,8 @@ void sl_cli_input_autocomplete(sl_cli_handle_t handle)
 #if SL_CLI_NUM_HISTORY_BYTES
 void sli_cli_input_update_history(sl_cli_handle_t handle)
 {
-  while ((strlen(handle->input_buffer) + 1) > (sizeof(handle->history_buf) - strlen(handle->history_buf))) {
+  // Use sl_strnlen() because history_buf is not null terminated
+  while ((strlen(handle->input_buffer) + 1) > (sizeof(handle->history_buf) - sl_strnlen(handle->history_buf, sizeof(handle->history_buf)))) {
     // Remove the oldest history string(s) to make space for the last
     size_t history_cnt = history_get_count(handle);
     size_t ofs_begin, ofs_end;


### PR DESCRIPTION
See https://community.silabs.com/s/question/0D58Y00009kws54SAA/bufferoverflowmemorycorruption-in-slcliinputc-when-using-history?language=en_US for an elaborate description.

If you "craft" (or are so unlucky that) your input-commands on the CLI align so that they fill up the history-buffer entirely, recalling a previous command from the history buffer with arrow-up/down and executing, will result in a buffer-overflow and trash neighboring data-structure.