### PR TITLE
Uart abort callback transfer count fix

### DIFF
--- a/platform/emdrv/uartdrv/src/uartdrv.c
+++ b/platform/emdrv/uartdrv/src/uartdrv.c
@@ -2141,7 +2141,7 @@ Ecode_t UARTDRV_Abort(UARTDRV_Handle_t handle, UARTDRV_AbortType_t type)
         if (txBuffer->callback != NULL) {
           txBuffer->callback(handle,
                              ECODE_EMDRV_UARTDRV_ABORTED,
-                             NULL,
+                             txBuffer->data,
                              txBuffer->transferCount - txBuffer->itemsRemaining);
         }
       }
@@ -2172,7 +2172,7 @@ Ecode_t UARTDRV_Abort(UARTDRV_Handle_t handle, UARTDRV_AbortType_t type)
         if (rxBuffer->callback != NULL) {
           rxBuffer->callback(handle,
                              ECODE_EMDRV_UARTDRV_ABORTED,
-                             NULL,
+                             rxBuffer->data,
                              rxBuffer->transferCount - rxBuffer->itemsRemaining);
         }
       }

--- a/platform/emdrv/uartdrv/src/uartdrv.c
+++ b/platform/emdrv/uartdrv/src/uartdrv.c
@@ -2142,7 +2142,7 @@ Ecode_t UARTDRV_Abort(UARTDRV_Handle_t handle, UARTDRV_AbortType_t type)
           txBuffer->callback(handle,
                              ECODE_EMDRV_UARTDRV_ABORTED,
                              NULL,
-                             txBuffer->itemsRemaining);
+                             txBuffer->transferCount - txBuffer->itemsRemaining);
         }
       }
     }
@@ -2173,7 +2173,7 @@ Ecode_t UARTDRV_Abort(UARTDRV_Handle_t handle, UARTDRV_AbortType_t type)
           rxBuffer->callback(handle,
                              ECODE_EMDRV_UARTDRV_ABORTED,
                              NULL,
-                             rxBuffer->itemsRemaining);
+                             rxBuffer->transferCount - rxBuffer->itemsRemaining);
         }
       }
     }


### PR DESCRIPTION
This fixes an inconsistency with the documentation as specified [here](https://docs.silabs.com/gecko-platform/4.2/driver/api/group-uartdrv#ga75a7670b4c9deaa47bc197bbde9b7fb4). If the UART callback is passed a different argument based on the error code, additional code has to be created to specially handle the abort case. This change makes it so that no special workarounds are required to handle the abort case when receiving bytes, particularly when there is a timeout for the read operation that triggers an abort and it is still desired to accept the bytes that were actually received. It also passes the correct data pointer, although this can't necessarily be used to disambiguate the buffers since the same buffer could be queued multiple times.