### PR TITLE
Fix typo in sl_sleeptimer_hal_rtc.c

### DIFF
--- a/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtc.c
+++ b/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtc.c
@@ -327,8 +327,8 @@ void sli_sleeptimer_set_pm_em_requirement(void)
   }
 #else
   switch ((CMU->LFACLKSEL & _CMU_LFACLKSEL_LFA_MASK) >> _CMU_LFACLKSEL_LFA_SHIFT) {
-    case CMU_LFCLKSEL_LFA_LFRCO:
-    case CMU_LFCLKSEL_LFA_LFXO:
+    case CMU_LFACLKSEL_LFA_LFRCO:
+    case CMU_LFACLKSEL_LFA_LFXO:
       sl_power_manager_add_em_requirement(SL_POWER_MANAGER_EM2);
       break;
     default:


### PR DESCRIPTION
sl_sleeptimer_hal_rtc.c incorrectly attempts to use `CMU_LFCLKSEL_LFA_LFRCO` and `CMU_LFCLKSEL_LFA_LFXO` macros to determine Power Manager lowest allowed power state in the `sli_sleeptimer_set_pm_em_requirement` function.

This fails to build on a project targeting an EFM32GG12B110F1024GM64 processor and would likely fail on any other part that has the LFA clock select mask

