### PR TITLE
Fix bootloader swo debug output undeclared variable with cortex-m3

### DIFF
--- a/platform/bootloader/debug/btl_debug_swo.c
+++ b/platform/bootloader/debug/btl_debug_swo.c
@@ -46,8 +46,11 @@ void btl_debugInit(void)
   GPIO->ROUTELOC0 = (GPIO->ROUTELOC0 & ~(_GPIO_ROUTELOC0_SWVLOC_MASK))
                     | SL_DEBUG_SWV_LOC;
 
+#if ((__CORTEX_M == 4) || (__CORTEX_M == 33))
   // Set TPIU prescaler to 22 (19 MHz / 22 = 863.63 kHz SWO speed)
   tpiu_prescaler_val = 22 - 1;
+#endif
+
 #endif
   // Enable output on pin
 #if (SL_DEBUG_SWV_PIN > 7U)


### PR DESCRIPTION
If the geko bootloader is used with a cortex-m3 processor (EFM32JG1B200), the project will not compile. This is due to the use of a variable which is not defined, as the declaration is not included by a preprocessor instruction. The variable may therefore only be used if it has also been declared.